### PR TITLE
Add serde feature for serializing Commits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ maintenance = { status = "passively-maintained" }
 nom = "6"
 unicase = "2.5"
 doc-comment = "0.3"
+serde = { version = "1.0", optional = true, features = ["derive"] }
 
 [dev-dependencies]
 indoc = "1.0"
+serde_test = "1.0"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -84,7 +84,7 @@ stages:
       parameters:
         rust: $(channel)
         targets: ["$(TARGET)"]
-    - script: cargo test --target $(TARGET) --workspace
+    - script: cargo test --all-features --target $(TARGET) --workspace
       displayName: cargo test
     - script: cargo doc --target $(TARGET) --workspace --no-deps
       displayName: cargo doc

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,7 +37,7 @@ stages:
     - template: install-rust.yml@templates
       parameters:
         rust: stable
-    - script: cargo check --workspace --all-targets
+    - script: cargo check --workspace --all-targets --no-default-features --all-features
       displayName: Default features
 - stage: test
   displayName: Test

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -14,7 +14,7 @@ const BREAKING_ARROW: &str = "BREAKING-CHANGE";
 
 /// A conventional commit.
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
-#[derive(Default, Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Commit<'a> {
     ty: Type<'a>,
     scope: Option<Scope<'a>>,
@@ -230,7 +230,7 @@ macro_rules! unicase_components {
     ($($ty:ident),+) => (
         $(
             /// A component of the conventional commit.
-            #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+            #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
             pub struct $ty<'a>(unicase::UniCase<&'a str>);
 
             impl<'a> $ty<'a> {


### PR DESCRIPTION
This adds 'serde' as optional dependency and makes the crate::Commit object serializable by implementing serde::Serialize.

Signed-off-by: orhun <orhun@archlinux.org>
