### PR TITLE
fix: Support whitespace-only bodies

### DIFF
--- a/src/commit.rs
+++ b/src/commit.rs
@@ -371,6 +371,71 @@ mod test {
     }
 
     #[test]
+    fn test_trailing_whitespace_without_body() {
+        let commit = Commit::parse("type(my scope): hello world\n\n\n").unwrap();
+
+        assert_eq!(commit.type_(), "type");
+        assert_eq!(commit.scope().unwrap(), "my scope");
+        assert_eq!(commit.description(), "hello world");
+    }
+
+    #[test]
+    fn test_trailing_1_nl() {
+        let commit = Commit::parse("type: hello world\n").unwrap();
+
+        assert_eq!(commit.type_(), "type");
+        assert_eq!(commit.scope(), None);
+        assert_eq!(commit.description(), "hello world");
+    }
+
+    #[test]
+    fn test_trailing_2_nl() {
+        let commit = Commit::parse("type: hello world\n\n").unwrap();
+
+        assert_eq!(commit.type_(), "type");
+        assert_eq!(commit.scope(), None);
+        assert_eq!(commit.description(), "hello world");
+    }
+
+    #[test]
+    fn test_trailing_3_nl() {
+        let commit = Commit::parse("type: hello world\n\n\n").unwrap();
+
+        assert_eq!(commit.type_(), "type");
+        assert_eq!(commit.scope(), None);
+        assert_eq!(commit.description(), "hello world");
+    }
+
+    #[test]
+    fn test_parenthetical_statement() {
+        let commit = Commit::parse("type: hello world (#1)").unwrap();
+
+        assert_eq!(commit.type_(), "type");
+        assert_eq!(commit.scope(), None);
+        assert_eq!(commit.description(), "hello world (#1)");
+    }
+
+    #[test]
+    fn test_issue_12_case_1() {
+        // Looks like it was test_trailing_2_nl that triggered this to fail originally
+        let commit = Commit::parse("chore: add .hello.txt (#1)\n\n").unwrap();
+
+        assert_eq!(commit.type_(), "chore");
+        assert_eq!(commit.scope(), None);
+        assert_eq!(commit.description(), "add .hello.txt (#1)");
+    }
+
+    #[test]
+    fn test_issue_12_case_2() {
+        // Looks like it was test_trailing_2_nl that triggered this to fail originally
+        let commit = Commit::parse("refactor: use fewer lines (#3)\n\n").unwrap();
+
+        assert_eq!(commit.type_(), "refactor");
+        assert_eq!(commit.scope(), None);
+        assert_eq!(commit.description(), "use fewer lines (#3)");
+    }
+
+    #[test]
     fn test_breaking_change() {
         let commit = Commit::parse("feat!: this is a breaking change").unwrap();
         assert_eq!(Type::FEAT, commit.type_());

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -23,9 +23,12 @@ pub(crate) fn parse<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
     i: &'a str,
 ) -> Result<CommitDetails<'a>, nom::Err<E>> {
     let (i, subject) = terminated(subject, alt((line_ending, eof)))(i)?;
-    let (i, body) = opt(preceded(line_ending, body))(i)?;
-    let (_, footers) = many0(footer)(i)?;
     let (type_, scope, breaking, description) = subject;
+
+    let (_, body) = opt(tuple((line_ending, body, many0(footer))))(i)?;
+    let (body, footers) = body
+        .map(|(_, body, footers)| (Some(body), footers))
+        .unwrap_or_else(|| (None, Default::default()));
 
     Ok((type_, scope, breaking.is_some(), description, body, footers))
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -140,7 +140,7 @@ fn body<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
     if i.is_empty() {
         let err = E::from_error_kind(i, ErrorKind::Eof);
         let err = E::add_context(i, BODY, err);
-        return Err(nom::Err::Failure(err));
+        return Err(nom::Err::Error(err));
     }
 
     let mut offset = 0;


### PR DESCRIPTION
This is allowing body parsing to fail and for us to fall back to it
being optional if its whitespace only.

Fixes #12