### PR TITLE
fix: return-values of `Commit::footers()` and `Commit::breaking_description()` use lifetime of message…

### DIFF
--- a/src/commit.rs
+++ b/src/commit.rs
@@ -104,7 +104,7 @@ impl<'a> Commit<'a> {
     ///
     /// Note: if no `BREAKING CHANGE` footer is provided, the `description` is expected to describe
     /// the breaking change.
-    pub fn breaking_description(&self) -> Option<&str> {
+    pub fn breaking_description(&self) -> Option<&'a str> {
         self.breaking_description
     }
 
@@ -114,7 +114,7 @@ impl<'a> Commit<'a> {
     /// requiring whitespace before newlines.
     ///
     /// See: <https://git-scm.com/docs/git-interpret-trailers>
-    pub fn footers(&self) -> &[Footer<'_>] {
+    pub fn footers(&self) -> &[Footer<'a>] {
         &self.footers
     }
 }


### PR DESCRIPTION
…instead of the one of `self` of the parsed structure, which allows
these return values to stay alive even after `Commit` perished.