### PR TITLE
Clarify error messages

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -118,9 +118,9 @@ impl fmt::Display for ErrorKind {
             ErrorKind::MissingType => "Missing type definition",
             ErrorKind::InvalidScope => "Invalid scope format",
             ErrorKind::MissingDescription => "Missing commit description",
-            ErrorKind::InvalidBody => "invalid body format",
-            ErrorKind::InvalidFooter => "invalid body footer",
-            ErrorKind::InvalidFormat => "invalid commit format",
+            ErrorKind::InvalidBody => "Invalid body format",
+            ErrorKind::InvalidFooter => "Invalid body footer",
+            ErrorKind::InvalidFormat => "Invalid commit format",
         };
         f.write_str(s)
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -31,6 +31,7 @@ impl Error {
                 for (_input, context) in &err.errors {
                     kind = match context {
                         Context(string) => match *string {
+                            crate::parser::SUMMARY => MissingType,
                             crate::parser::TYPE => MissingType,
                             crate::parser::SCOPE => InvalidScope,
                             crate::parser::DESCRIPTION => MissingDescription,

--- a/src/error.rs
+++ b/src/error.rs
@@ -115,12 +115,18 @@ pub enum ErrorKind {
 impl fmt::Display for ErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let s = match self {
-            ErrorKind::MissingType => "Missing type definition",
-            ErrorKind::InvalidScope => "Invalid scope format",
-            ErrorKind::MissingDescription => "Missing commit description",
-            ErrorKind::InvalidBody => "Invalid body format",
-            ErrorKind::InvalidFooter => "Invalid body footer",
-            ErrorKind::InvalidFormat => "Invalid commit format",
+            ErrorKind::MissingType => {
+                "Missing type in the commit summary, expected `type: description`"
+            }
+            ErrorKind::InvalidScope => {
+                "Incorrect scope syntax in commit summary, expected `type(scope): description`"
+            }
+            ErrorKind::MissingDescription => {
+                "Missing description in commit summary, expected `type: description`"
+            }
+            ErrorKind::InvalidBody => "Incorrect body syntax",
+            ErrorKind::InvalidFooter => "Incorrect footer syntax",
+            ErrorKind::InvalidFormat => "Incorrect conventional commit format",
         };
         f.write_str(s)
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -111,14 +111,18 @@ pub(crate) const SCOPE: &str = "scope";
 fn summary<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
     i: &'a str,
 ) -> IResult<&'a str, (&'a str, Option<&'a str>, Option<&'a str>, &'a str), E> {
-    tuple((
-        type_,
-        opt(delimited(char('('), cut(scope), char(')'))),
-        opt(exclamation_mark),
-        preceded(tuple((tag(":"), whitespace)), context(DESCRIPTION, text)),
-    ))(i)
+    context(
+        SUMMARY,
+        tuple((
+            type_,
+            opt(delimited(char('('), cut(scope), char(')'))),
+            opt(exclamation_mark),
+            preceded(tuple((tag(":"), whitespace)), context(DESCRIPTION, text)),
+        )),
+    )(i)
 }
 
+pub(crate) const SUMMARY: &str = "SUMMARY";
 pub(crate) const DESCRIPTION: &str = "description";
 
 // <text>            ::= <any UTF8-octets except newline>*
@@ -235,7 +239,7 @@ mod tests {
             let input = "Hello World";
             let err = test(p, input).unwrap_err();
             let err = crate::Error::with_nom(input, err);
-            assert_eq!(err.to_string(), "invalid commit format");
+            assert_eq!(err.to_string(), "Missing type definition");
         }
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -239,7 +239,7 @@ mod tests {
             let input = "Hello World";
             let err = test(p, input).unwrap_err();
             let err = crate::Error::with_nom(input, err);
-            assert_eq!(err.to_string(), "Missing type definition");
+            assert_eq!(err.to_string(), crate::ErrorKind::MissingType.to_string());
         }
     }
 


### PR DESCRIPTION
Frequently with committed, the error messages make it hard to know what to do.  Trying to make the path forward clearer.