### PR TITLE
fix: Support windows newlines 

### DIFF
--- a/src/commit.rs
+++ b/src/commit.rs
@@ -472,6 +472,26 @@ mod test {
     }
 
     #[test]
+    fn test_extra_line_endings() {
+        let commit =
+            Commit::parse("feat: thing\n\n\n\n\nbody\n\n\n\n\ncloses #1234\n\n\n\n\n\nBREAKING CHANGE: something broke\n\n\n\n")
+                .unwrap();
+        assert_eq!(commit.body(), Some("body"));
+        assert_eq!(
+            commit.footers(),
+            [
+                Footer::new(FooterToken("closes".into()), FooterSeparator::Ref, "1234"),
+                Footer::new(
+                    FooterToken("BREAKING CHANGE".into()),
+                    FooterSeparator::Value,
+                    "something broke"
+                ),
+            ]
+        );
+        assert_eq!(commit.breaking_description(), Some("something broke"));
+    }
+
+    #[test]
     fn test_valid_complex_commit() {
         let commit = indoc! {"
             chore: improve changelog readability

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -472,6 +472,26 @@ mod test {
     }
 
     #[test]
+    fn test_windows_line_endings() {
+        let commit =
+            Commit::parse("feat: thing\r\n\r\nbody\r\n\r\ncloses #1234\r\n\r\n\r\nBREAKING CHANGE: something broke\r\n\r\n")
+                .unwrap();
+        assert_eq!(commit.body(), Some("body"));
+        assert_eq!(
+            commit.footers(),
+            [
+                Footer::new(FooterToken("closes".into()), FooterSeparator::Ref, "1234"),
+                Footer::new(
+                    FooterToken("BREAKING CHANGE".into()),
+                    FooterSeparator::Value,
+                    "something broke"
+                ),
+            ]
+        );
+        assert_eq!(commit.breaking_description(), Some("something broke"));
+    }
+
+    #[test]
     fn test_extra_line_endings() {
         let commit =
             Commit::parse("feat: thing\n\n\n\n\nbody\n\n\n\n\ncloses #1234\n\n\n\n\n\nBREAKING CHANGE: something broke\n\n\n\n")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@
 
 mod commit;
 mod error;
+mod lines;
 mod parser;
 
 pub use commit::{Commit, Footer, FooterSeparator, FooterToken, Scope, Type};

--- a/src/lines.rs
+++ b/src/lines.rs
@@ -1,0 +1,31 @@
+#[derive(Clone, Debug)]
+pub(crate) struct LinesWithTerminator<'a> {
+    data: &'a str,
+}
+
+impl<'a> LinesWithTerminator<'a> {
+    pub(crate) fn new(data: &'a str) -> LinesWithTerminator<'a> {
+        LinesWithTerminator { data }
+    }
+}
+
+impl<'a> Iterator for LinesWithTerminator<'a> {
+    type Item = &'a str;
+
+    #[inline]
+    fn next(&mut self) -> Option<&'a str> {
+        match self.data.find('\n') {
+            None if self.data.is_empty() => None,
+            None => {
+                let line = self.data;
+                self.data = "";
+                Some(line)
+            }
+            Some(end) => {
+                let line = &self.data[..end + 1];
+                self.data = &self.data[end + 1..];
+                Some(line)
+            }
+        }
+    }
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -144,16 +144,15 @@ fn body<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
     }
 
     let mut offset = 0;
-    for line in i.lines() {
-        if peek::<_, _, E, _>(tuple((token, separator)))(line).is_ok() {
-            offset += 1;
+    for line in crate::lines::LinesWithTerminator::new(i) {
+        if peek::<_, _, E, _>(tuple((token, separator)))(line.trim_end()).is_ok() {
             break;
         }
 
-        offset += line.chars().count() + 1;
+        offset += line.chars().count();
     }
 
-    map(take(offset - 1), str::trim_end)(i)
+    map(take(offset), str::trim_end)(i)
 }
 
 pub(crate) const BODY: &str = "body";
@@ -192,16 +191,15 @@ pub(crate) fn value<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
     }
 
     let mut offset = 0;
-    for line in i.lines() {
-        if peek::<_, _, E, _>(tuple((token, separator)))(line).is_ok() {
-            offset += 1;
+    for line in crate::lines::LinesWithTerminator::new(i) {
+        if peek::<_, _, E, _>(tuple((token, separator)))(line.trim_end()).is_ok() {
             break;
         }
 
-        offset += line.chars().count() + 1;
+        offset += line.chars().count();
     }
 
-    map(take(offset - 1), str::trim_end)(i)
+    map(take(offset), str::trim_end)(i)
 }
 
 fn exclamation_mark<'a, E: ParseError<&'a str> + ContextError<&'a str>>(

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -143,16 +143,7 @@ fn body<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
         return Err(nom::Err::Error(err));
     }
 
-    let mut offset = 0;
-    for line in crate::lines::LinesWithTerminator::new(i) {
-        if peek::<_, _, E, _>(tuple((token, separator)))(line.trim_end()).is_ok() {
-            break;
-        }
-
-        offset += line.chars().count();
-    }
-
-    map(take(offset), str::trim_end)(i)
+    take_until_footer(i)
 }
 
 pub(crate) const BODY: &str = "body";
@@ -190,6 +181,12 @@ pub(crate) fn value<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
         return Err(nom::Err::Failure(err));
     }
 
+    take_until_footer(i)
+}
+
+fn take_until_footer<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
+    i: &'a str,
+) -> IResult<&'a str, &'a str, E> {
     let mut offset = 0;
     for line in crate::lines::LinesWithTerminator::new(i) {
         if peek::<_, _, E, _>(tuple((token, separator)))(line.trim_end()).is_ok() {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -5,7 +5,7 @@ use nom::bytes::complete::{tag, take, take_till1, take_while, take_while1};
 use nom::character::complete::{char, line_ending};
 use nom::combinator::{cut, eof, map, opt, peek};
 use nom::error::{context, ContextError, ErrorKind, ParseError};
-use nom::multi::many0;
+use nom::multi::{many0, many1};
 use nom::sequence::{delimited, preceded, terminated, tuple};
 use nom::IResult;
 use nom::Parser;
@@ -68,7 +68,7 @@ pub(crate) fn message<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
     let (i, summary) = terminated(summary, alt((line_ending, eof)))(i)?;
     let (type_, scope, breaking, description) = summary;
 
-    let (i, body) = opt(tuple((line_ending, body, many0(footer))))(i)?;
+    let (i, body) = opt(tuple((many1(line_ending), body, many0(footer))))(i)?;
     let (body, footers) = body
         .map(|(_, body, footers)| (Some(body), footers))
         .unwrap_or_else(|| (None, Default::default()));

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -23,6 +23,7 @@ pub(crate) fn parse<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
     i: &'a str,
 ) -> Result<CommitDetails<'a>, nom::Err<E>> {
     let (_i, c) = message(i)?;
+    debug_assert!(_i.is_empty(), "{:?} remaining", _i);
     Ok(c)
 }
 
@@ -71,6 +72,7 @@ pub(crate) fn message<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
     let (body, footers) = body
         .map(|(_, body, footers)| (Some(body), footers))
         .unwrap_or_else(|| (None, Default::default()));
+    let (i, _trailing) = many0(line_ending)(i)?;
 
     Ok((
         i,


### PR DESCRIPTION
We supported them in main part of our parsers but when we parse `body`
and `footer`, we peek ahead but assumed a 1 char line ending.  We now
take any of the line endings.

Fixes #21