### PR TITLE
fix(parser): Always consume current line for footer 

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,1 +1,1 @@
-msrv = "1.54.0"  # MSRV
+msrv = "1.60.0"  # MSRV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
     - name: No-default features
       run: cargo test --workspace --no-default-features
   msrv:
-    name: "Check MSRV: 1.50.0"
+    name: "Check MSRV: 1.60.0"
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
@@ -59,7 +59,7 @@ jobs:
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.50.0  # MSRV
+        toolchain: 1.60.0  # MSRV
         profile: minimal
         override: true
     - uses: Swatinem/rust-cache@v2
@@ -113,7 +113,7 @@ jobs:
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.50.0  # MSRV
+        toolchain: 1.60.0  # MSRV
         profile: minimal
         override: true
         components: clippy

--- a/.github/workflows/rust-next.yml
+++ b/.github/workflows/rust-next.yml
@@ -57,9 +57,9 @@ jobs:
     strategy:
       matrix:
         rust:
-        - 1.50.0  # MSRV
+        - 1.60.0  # MSRV
         - stable
-    continue-on-error: ${{ matrix.rust != '1.50.0' }}  # MSRV
+    continue-on-error: ${{ matrix.rust != '1.60.0' }}  # MSRV
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,9 @@ pre-release-replacements = [
   {file="CHANGELOG.md", search="<!-- next-url -->", replace="<!-- next-url -->\n[Unreleased]: https://github.com/crate-ci/git-conventional/compare/{{tag_name}}...HEAD", exactly=1},
 ]
 
+[features]
+unstable-trace = []
+
 [dependencies]
 nom = "7"
 unicase = "2.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 categories = ["parser-implementations"]
 keywords = ["parser", "git", "conventional-commit", "commit", "conventional"]
 edition = "2018"
+rust-version = "1.60.0"  # MSRV
 include = [
   "src/**/*",
   "Cargo.toml",

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -481,6 +481,26 @@ mod test {
     }
 
     #[test]
+    fn test_conjoined_footer() {
+        let commit = Commit::parse(
+            "fix(example): fix keepachangelog config example
+
+Fixes: #123, #124, #125",
+        )
+        .unwrap();
+        assert_eq!(Type::FIX, commit.type_());
+        assert_eq!(commit.body(), None);
+        assert_eq!(
+            commit.footers(),
+            [Footer::new(
+                FooterToken("Fixes".into()),
+                FooterSeparator::Value,
+                "#123, #124, #125"
+            ),]
+        );
+    }
+
+    #[test]
     fn test_windows_line_endings() {
         let commit =
             Commit::parse("feat: thing\r\n\r\nbody\r\n\r\ncloses #1234\r\n\r\n\r\nBREAKING CHANGE: something broke\r\n\r\n")


### PR DESCRIPTION
When parsing the footer, we were checking until then next footer but we
didn't wait until a newline for that, now we do.

Fixes #34