### PR TITLE
fix: footer seperator `:` requires space

### DIFF
--- a/src/commit.rs
+++ b/src/commit.rs
@@ -189,7 +189,7 @@ impl<'a> Footer<'a> {
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 #[non_exhaustive]
 pub enum FooterSeparator {
-    /// ":"
+    /// ": "
     Value,
 
     /// " #"
@@ -200,7 +200,7 @@ impl FooterSeparator {
     /// Access `str` representation of FooterSeparator
     pub fn as_str(self) -> &'static str {
         match self {
-            FooterSeparator::Value => ":",
+            FooterSeparator::Value => ": ",
             FooterSeparator::Ref => " #",
         }
     }
@@ -231,7 +231,7 @@ impl FromStr for FooterSeparator {
 
     fn from_str(sep: &str) -> Result<Self, Self::Err> {
         match sep {
-            ":" => Ok(FooterSeparator::Value),
+            ": " => Ok(FooterSeparator::Value),
             " #" => Ok(FooterSeparator::Ref),
             _ => {
                 Err(Error::new(ErrorKind::InvalidFooter)
@@ -625,5 +625,21 @@ Fixes: #123, #124, #125",
                 Token::StructEnd,
             ],
         );
+    }
+
+    #[test]
+    fn footer_with_value_sep_requires_space_after_colon() {
+        let commit = indoc! {"
+            fix: something something
+
+            First line of the body
+
+            Invalid-footer:space required
+
+            Valid #footer
+        "};
+
+        let commit = Commit::parse(commit).unwrap();
+        assert_eq!(1, commit.footers.len());
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -222,11 +222,11 @@ pub(crate) fn token<
     trace("token", alt(("BREAKING CHANGE", type_))).parse_next(i)
 }
 
-// <separator>       ::= ":" | " #"
+// <separator>       ::= ": " | " #"
 fn separator<'a, E: ParserError<&'a str> + AddContext<&'a str, StrContext> + std::fmt::Debug>(
     i: &mut &'a str,
 ) -> PResult<&'a str, E> {
-    trace("sep", alt((":", " #"))).parse_next(i)
+    trace("sep", alt((": ", " #"))).parse_next(i)
 }
 
 pub(crate) fn value<
@@ -459,18 +459,18 @@ mod tests {
             // valid
             assert_eq!(
                 p.parse_peek("hello: world").unwrap(),
-                ("", ("hello", ":", "world"))
+                ("", ("hello", ": ", "world"))
             );
             assert_eq!(
                 p.parse_peek("BREAKING CHANGE: woops!").unwrap(),
-                ("", ("BREAKING CHANGE", ":", "woops!"))
+                ("", ("BREAKING CHANGE", ": ", "woops!"))
             );
             assert_eq!(
                 p.parse_peek("Co-Authored-By: Marge Simpson <marge@simpsons.com>")
                     .unwrap(),
                 (
                     "",
-                    ("Co-Authored-By", ":", "Marge Simpson <marge@simpsons.com>")
+                    ("Co-Authored-By", ": ", "Marge Simpson <marge@simpsons.com>")
                 )
             );
             assert_eq!(
@@ -479,7 +479,7 @@ mod tests {
             );
             assert_eq!(
                 p.parse_peek("BREAKING-CHANGE: broken").unwrap(),
-                ("", ("BREAKING-CHANGE", ":", "broken"))
+                ("", ("BREAKING-CHANGE", ": ", "broken"))
             );
 
             // invalid


### PR DESCRIPTION
According to the conventional commits specification v1.0.0 §8: “Each footer MUST consist of a word token, followed by either a `:<space>` or `<space>#` separator, followed by a string value.”

Previously, the separator `:` was accepted. Now, lines missing a space between the colon and the following string value are not parsed as footers.